### PR TITLE
Remove custom install experience post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,7 +1310,6 @@ Learn how to make your web app installable.
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fweb.dev" alt="Logo" /> web.dev - Installable](https://web.dev/installable)
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fdevelopers.google.com" alt="Logo" /> Google Devs - App Install Banners](https://developers.google.com/web/fundamentals/app-install-banners/)
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fdeveloper.mozilla.org" alt="Logo" /> MDN - Add to Home screen](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Add_to_home_screen)
-* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fweb.dev" alt="Logo" /> web.dev - Provide a custom install experience](https://web.dev/customize-install/)
 
 ### Touch Events
 

--- a/blueprint.md
+++ b/blueprint.md
@@ -909,7 +909,6 @@ Learn how to make your web app installable.
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fweb.dev" alt="Logo" /> web.dev - Installable](https://web.dev/installable)
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fdevelopers.google.com" alt="Logo" /> Google Devs - App Install Banners](https://developers.google.com/web/fundamentals/app-install-banners/)
 * [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fdeveloper.mozilla.org" alt="Logo" /> MDN - Add to Home screen](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Add_to_home_screen)
-* [ ] [<img style="margin-bottom: 0;" src="https://plus.google.com/_/favicon?domain_url=https%3A%2F%2Fweb.dev" alt="Logo" /> web.dev - Provide a custom install experience](https://web.dev/customize-install/)
 
 ### Touch Events
 

--- a/src/data/pwa.js
+++ b/src/data/pwa.js
@@ -114,8 +114,7 @@ export const pwaCollection = {
 						links: [
 							["web.dev - Installable", "https://web.dev/installable"],
 							["Google Devs - App Install Banners", "https://developers.google.com/web/fundamentals/app-install-banners/"],
-							["MDN - Add to Home screen", "https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Add_to_home_screen"],
-							["web.dev - Provide a custom install experience", "https://web.dev/customize-install/"],
+							["MDN - Add to Home screen", "https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Add_to_home_screen"]
 						]
 					}
 				},


### PR DESCRIPTION
The `beforeinstallprompt` event that is described in the blog post has been removed from the spec as Safari and Mozilla will not implement it. So this feature is now Chrome-only.

Please consider removing this blog post, as I suggested in https://github.com/andreasbm/web-skills/issues/21#issuecomment-613393217

See w3c/manifest#835 and https://github.com/w3c/manifest/pull/836