### PR TITLE
Only capture mouse button 0 for click-and-drag

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -393,7 +393,7 @@ export class App extends LitElement {
 
 		// Listen for drag start
 		window.addEventListener("mousedown", e => {
-			if (this.compact || isDialogVisible()) {
+			if (e.button !== 0 || this.compact || isDialogVisible()) {
 				return;
 			}
 


### PR DESCRIPTION
Middle mouse click is used to scroll, and should not be captured as a drag event. Right click (or any other mouse button) should not start a drag either.